### PR TITLE
Fix example build-system table for Flit

### DIFF
--- a/doc/pypa-the-missing-outline.md
+++ b/doc/pypa-the-missing-outline.md
@@ -96,8 +96,8 @@ Here is a table for using `setuptools`:
 or for `flit`:
 
     [build-system]
-    requires = ["flit"]
-    build-backend = "flit.api:main"
+    requires = ["flit_core >=3.2,<4"]
+    build-backend = "flit_core.buildapi"
 
 With such a table in the `pyproject.toml` file
 a tool like [build](https://pypi.org/project/build/)


### PR DESCRIPTION
Copying from [Flit's docs](https://flit.pypa.io/en/latest/) - `flit.api` doesn't exist, and `flit_core` is a smaller package specifically meant to be used as a build dependency like this. :slightly_smiling_face: 