### PR TITLE
Remove pyicontract-lint

### DIFF
--- a/bin-cs/lint
+++ b/bin-cs/lint
@@ -19,7 +19,6 @@ pyflakes2=pyflakes-2.7
 pyflakes3='python3 -m pyflakes'
 pylint2=pylint-2.7
 pylint3='python3 -m pylint'
-pyiclint=pyicontract-lint
 pycodestyle_ignore=E111,E114,E124,E125,E126,E129,E201,E202,E127,E221,E226,E227,E265,E266,E301,E302,E305,E501,E731,W503,W504
 # pylint no longer supports: bad-whitespace,bad-continuation
 pylint_disable=bad-indentation,invalid-name,useless-object-inheritance,consider-using-f-string,use-dict-literal
@@ -140,7 +139,6 @@ do
           $trace $pyflakes "$lintfile" || xit=1
           [ $quick ] || $trace $pycodestyle "--ignore=$pycodestyle_ignore" "$lintfile" || xit=1
           ##[ $quick ] || $trace $pylint "--rcfile=$pylintrc" "--disable=$pylint_disable" "$lintfile" || xit=1
-          ##[ $quick ] || $trace $pyiclint "$lintfile" || xit=1
         fi
         exit $xit
       ) || xit=1

--- a/venv-requirements.txt
+++ b/venv-requirements.txt
@@ -23,7 +23,6 @@ pycodestyle
 # used by dedrm
 pycryptodome
 pyflakes
-pyicontract-lint
 pylint
 ##pylzma - seems to be stale, what was I using this for? - cameron 30nov2024
 ##pyobjc[allbindings]  ## macos only


### PR DESCRIPTION
It has been abandoned and is no longer maintained. It raises this message during install:
> DEPRECATION: Building 'pyicontract-lint' using the legacy setup.py bdist_wheel mechanism, which will be removed in a future version. pip 25.3 will enforce this behaviour change. A possible replacement is to use the standardized build interface by setting the --use-pep517 option, (possibly combined with --no-build-isolation),
or adding a pyproject.toml file to the source tree of 'pyicontract-lint'. Discussion can be found at https://github.com/pypa/pip/issues/6334.

Looks like it was only used in a single line which was commented out, so I've just removed it.